### PR TITLE
Add support for null line endings

### DIFF
--- a/src/PromptMatcher.php
+++ b/src/PromptMatcher.php
@@ -36,7 +36,7 @@ class PromptMatcher implements PromptMatcherInterface
     public function isMatch($prompt, $subject, $lineEnding = null)
     {
         // cheap line ending check before expensive regex
-        if (substr($subject, -1 * strlen($lineEnding)) != $lineEnding) {
+        if (!is_null($lineEnding) && substr($subject, -1 * strlen($lineEnding)) != $lineEnding) {
             return false;
         }
 

--- a/tests/unit/PromptMatcherTest.php
+++ b/tests/unit/PromptMatcherTest.php
@@ -39,6 +39,7 @@ class PromptMatcherTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['OK', 'this is a response', "\n", false],
+            ['OK', 'this is a response', null, false], // null line ending
             ['OK', "this is a response\nOK\n", "\n", true, ['OK'], 'this is a response'],
             ['(ERROR) ([0-9]{1,3})', "party\r\nERROR 123\r\n", "\r\n", true, ['ERROR 123', 'ERROR', '123'], 'party']
         ];


### PR DESCRIPTION
Some telnet implementations do not end sends with a consistent line ending. Add support for those implementations by removing the line ending check if `$lineEnding === null`.

Prompt matching will be more expensive in these instances as each character received will be checked against the prompt regex.