### PR TITLE
Added $promptError as an additional parameter to execute()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
   - nightly
 
 env:

--- a/src/TelnetClient.php
+++ b/src/TelnetClient.php
@@ -177,14 +177,14 @@ class TelnetClient implements TelnetClientInterface
      *
      * @return \Graze\TelnetClient\TelnetResponseInterface
      */
-    public function execute($command, $prompt = null)
+    public function execute($command, $prompt = null, $promptError = null)
     {
         if (!$this->socket) {
             throw new TelnetException('attempt to execute without a connection - call connect first');
         }
 
         $this->write($command);
-        return $this->getResponse($prompt);
+        return $this->getResponse($prompt, $promptError);
     }
 
     /**
@@ -208,7 +208,7 @@ class TelnetClient implements TelnetClientInterface
      * @return \Graze\TelnetClient\TelnetResponseInterface
      * @throws TelnetExceptionInterface
      */
-    protected function getResponse($prompt = null)
+    protected function getResponse($prompt = null, $promptError = null)
     {
         $isError = false;
         $buffer = '';
@@ -236,7 +236,7 @@ class TelnetClient implements TelnetClientInterface
             }
 
             // check for error prompt
-            if ($this->promptMatcher->isMatch($this->promptError, $buffer, $this->lineEnding)) {
+            if ($this->promptMatcher->isMatch($promptError ?: $this->promptError, $buffer, $this->lineEnding)) {
                 $isError = true;
                 break;
             }

--- a/src/TelnetClient.php
+++ b/src/TelnetClient.php
@@ -174,6 +174,7 @@ class TelnetClient implements TelnetClientInterface
     /**
      * @param string $command
      * @param string $prompt
+     * @param string $promptError
      *
      * @return \Graze\TelnetClient\TelnetResponseInterface
      */
@@ -204,6 +205,7 @@ class TelnetClient implements TelnetClientInterface
 
     /**
      * @param string $prompt
+     * @param string $promptError
      *
      * @return \Graze\TelnetClient\TelnetResponseInterface
      * @throws TelnetExceptionInterface

--- a/tests/unit/TelnetClientTest.php
+++ b/tests/unit/TelnetClientTest.php
@@ -213,7 +213,7 @@ class TelnetClientTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $telnetClient = new TelnetClient($socketFactory, $promptMatcher, $interpretAsCommand);
-        $telnetClient->connect('127.0.0.1:23', $promptGlobal, NULL, $lineEnding);
+        $telnetClient->connect('127.0.0.1:23', $promptGlobal, null, $lineEnding);
 
         $response = $telnetClient->execute($command, $promptLocal, $promptError);
         $this->assertInstanceOf(TelnetResponseInterface::class, $response);


### PR DESCRIPTION
As proposed in issue #18 and finally making the change today, I've added the `$promtError` parameter to the execute method.

This allows `$promptError` to be evaluated dynamically (per execute call) rather than statically (only on connect) as is done currently.

I've added a unit test method. I've run this manually using phpunit (instead of make test).