### PR TITLE
Add max read characters

### DIFF
--- a/src/TelnetClient.php
+++ b/src/TelnetClient.php
@@ -55,7 +55,7 @@ class TelnetClient implements TelnetClientInterface
     /**
      * @var int
      */
-    protected $maxReadBytes = 0;
+    protected $maxBytesRead = 0;
 
     /**
      * @var Socket
@@ -159,11 +159,11 @@ class TelnetClient implements TelnetClientInterface
     /**
      * Set the maximum number of bytes that can be read per request
      *
-     * @param int $maxReadBytes
+     * @param int $maxBytesRead
      */
-    public function setMaxReadBytes($maxReadBytes)
+    public function setMaxBytesRead($maxBytesRead)
     {
-        $this->maxReadBytes = $maxReadBytes;
+        $this->maxBytesRead = $maxBytesRead;
     }
 
     /**
@@ -225,10 +225,12 @@ class TelnetClient implements TelnetClientInterface
     {
         $isError = false;
         $buffer = '';
+        $bytesRead = 0;
         do {
             // process one byte at a time
             try {
                 $byte = $this->socket->read(1);
+                $bytesRead++;
             } catch (Exception $e) {
                 throw new TelnetException('failed reading from socket', 0, $e);
             }
@@ -255,10 +257,10 @@ class TelnetClient implements TelnetClientInterface
             }
 
             // throw an exception if the number of bytes read is greater than the limit
-            if ($this->maxReadBytes > 0 && strlen($buffer) >= $this->maxReadBytes) {
+            if ($this->maxBytesRead > 0 && $bytesRead >= $this->maxBytesRead) {
                 throw new TelnetException(sprintf(
                     'Maximum number of bytes read (%d), the last bytes were %s',
-                    $this->maxReadBytes,
+                    $this->maxBytesRead,
                     substr($buffer, -10)
                 ));
             }

--- a/src/TelnetClient.php
+++ b/src/TelnetClient.php
@@ -53,6 +53,11 @@ class TelnetClient implements TelnetClientInterface
     protected $lineEnding = "\n";
 
     /**
+     * @var int
+     */
+    protected $maxReadCharacters = 0;
+
+    /**
      * @var Socket
      */
     protected $socket;
@@ -152,6 +157,16 @@ class TelnetClient implements TelnetClientInterface
     }
 
     /**
+     * Set the maximum number of characters that can be read per request
+     *
+     * @param int $maxReadCharacters
+     */
+    public function setMaxReadCharacters($maxReadCharacters)
+    {
+        $this->maxReadCharacters = $maxReadCharacters;
+    }
+
+    /**
      * @param Socket $socket
      */
     public function setSocket(Socket $socket)
@@ -237,6 +252,15 @@ class TelnetClient implements TelnetClientInterface
             if ($this->promptMatcher->isMatch($promptError ?: $this->promptError, $buffer, $this->lineEnding)) {
                 $isError = true;
                 break;
+            }
+
+            // throw an exception if the number of characters read is greater than the limit
+            if ($this->maxReadCharacters > 0 && strlen($buffer) >= $this->maxReadCharacters) {
+                throw new TelnetException(sprintf(
+                    'Maximum number of characters read (%d), the last characters were %s',
+                    $this->maxReadCharacters,
+                    substr($buffer, -10)
+                ));
             }
         } while (true);
 

--- a/src/TelnetClient.php
+++ b/src/TelnetClient.php
@@ -55,7 +55,7 @@ class TelnetClient implements TelnetClientInterface
     /**
      * @var int
      */
-    protected $maxReadCharacters = 0;
+    protected $maxReadBytes = 0;
 
     /**
      * @var Socket
@@ -157,13 +157,13 @@ class TelnetClient implements TelnetClientInterface
     }
 
     /**
-     * Set the maximum number of characters that can be read per request
+     * Set the maximum number of bytes that can be read per request
      *
-     * @param int $maxReadCharacters
+     * @param int $maxReadBytes
      */
-    public function setMaxReadCharacters($maxReadCharacters)
+    public function setMaxReadBytes($maxReadBytes)
     {
-        $this->maxReadCharacters = $maxReadCharacters;
+        $this->maxReadBytes = $maxReadBytes;
     }
 
     /**
@@ -226,22 +226,22 @@ class TelnetClient implements TelnetClientInterface
         $isError = false;
         $buffer = '';
         do {
-            // process one character at a time
+            // process one byte at a time
             try {
-                $character = $this->socket->read(1);
+                $byte = $this->socket->read(1);
             } catch (Exception $e) {
                 throw new TelnetException('failed reading from socket', 0, $e);
             }
 
-            if (in_array($character, [$this->NULL, $this->DC1])) {
+            if (in_array($byte, [$this->NULL, $this->DC1])) {
                 break;
             }
 
-            if ($this->interpretAsCommand->interpret($character, $this->socket)) {
+            if ($this->interpretAsCommand->interpret($byte, $this->socket)) {
                 continue;
             }
 
-            $buffer .= $character;
+            $buffer .= $byte;
 
             // check for prompt
             if ($this->promptMatcher->isMatch($prompt ?: $this->prompt, $buffer, $this->lineEnding)) {
@@ -254,11 +254,11 @@ class TelnetClient implements TelnetClientInterface
                 break;
             }
 
-            // throw an exception if the number of characters read is greater than the limit
-            if ($this->maxReadCharacters > 0 && strlen($buffer) >= $this->maxReadCharacters) {
+            // throw an exception if the number of bytes read is greater than the limit
+            if ($this->maxReadBytes > 0 && strlen($buffer) >= $this->maxReadBytes) {
                 throw new TelnetException(sprintf(
-                    'Maximum number of characters read (%d), the last characters were %s',
-                    $this->maxReadCharacters,
+                    'Maximum number of bytes read (%d), the last bytes were %s',
+                    $this->maxReadBytes,
                     substr($buffer, -10)
                 ));
             }

--- a/tests/unit/TelnetClientTest.php
+++ b/tests/unit/TelnetClientTest.php
@@ -286,7 +286,7 @@ class TelnetClientTest extends PHPUnit_Framework_TestCase
         $client->execute('aCommand');
     }
 
-    public function testMaxReadBytesException()
+    public function testMaxBytesReadException()
     {
         $this->setExpectedException(
             TelnetExceptionInterface::class, 
@@ -316,7 +316,7 @@ class TelnetClientTest extends PHPUnit_Framework_TestCase
 
         $client = new TelnetClient($socketFactory, $promptMatcher, $interpretAsCommand);
         $client->connect('dsn');
-        $client->setMaxReadBytes(20);
+        $client->setMaxBytesRead(20);
 
         $client->execute('aCommand');
     }

--- a/tests/unit/TelnetClientTest.php
+++ b/tests/unit/TelnetClientTest.php
@@ -122,7 +122,7 @@ class TelnetClientTest extends PHPUnit_Framework_TestCase
             ->with($command.$lineEnding)
             ->once();
 
-        // echo the command back when reading each character one-by-one from the socket
+        // echo the command back when reading each byte one-by-one from the socket
         $commandResponse = str_split($command.$lineEnding.$promptResponse.$lineEnding);
         $socket = $socket
             ->shouldReceive('read')
@@ -190,7 +190,7 @@ class TelnetClientTest extends PHPUnit_Framework_TestCase
             ->with($command.$lineEnding)
             ->once();
 
-        // echo the command back when reading each character one-by-one from the socket
+        // echo the command back when reading each byte one-by-one from the socket
         $commandResponse = str_split($command.$lineEnding.$promptResponse.$lineEnding);
         $socket = $socket
             ->shouldReceive('read')
@@ -286,11 +286,11 @@ class TelnetClientTest extends PHPUnit_Framework_TestCase
         $client->execute('aCommand');
     }
 
-    public function testMaxReadCharactersException()
+    public function testMaxReadBytesException()
     {
         $this->setExpectedException(
             TelnetExceptionInterface::class, 
-            'Maximum number of characters read (20), the last characters were 0123456789'
+            'Maximum number of bytes read (20), the last bytes were 0123456789'
         );
 
         $socket = m::mock(Socket::class)
@@ -316,7 +316,7 @@ class TelnetClientTest extends PHPUnit_Framework_TestCase
 
         $client = new TelnetClient($socketFactory, $promptMatcher, $interpretAsCommand);
         $client->connect('dsn');
-        $client->setMaxReadCharacters(20);
+        $client->setMaxReadBytes(20);
 
         $client->execute('aCommand');
     }


### PR DESCRIPTION
Add support for a maximum number of characters to read, once this limit is reached an exception is thrown.

This is to prevent an infinite loop if the prompt is never returned/matched.